### PR TITLE
Fix: asterisk color in body copy matches text

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,7 +224,7 @@
     .tl-phase__body sup {
       font-size: 0.6em;
       vertical-align: super;
-      color: rgba(255,255,255,0.4);
+      color: inherit;
       margin-left: 1px;
     }
 


### PR DESCRIPTION
Fixes #4

Changed `.tl-phase__body sup` color from hardcoded `rgba(255,255,255,0.4)` to `inherit` so asterisks and daggers always match the surrounding body copy color.

Generated with [Claude Code](https://claude.ai/code)